### PR TITLE
Remove reliance on Font Awesome for icons

### DIFF
--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -5,7 +5,56 @@
 {{- $block := findRE "(?is)^<(?:address|article|aside|blockquote|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h(?:1|2|3|4|5|6)|header|hgroup|hr|li|main|nav|noscript|ol|output|p|pre|section|table|tfoot|ul|video)\\b" $raw 1 -}}
 {{/* Count how many times we've called this shortcode and load the css if it's the first time */}}
 {{- if not ($.Page.Scratch.Get "noticecount") -}}
-<style type="text/css">.notice{padding:18px;line-height:24px;margin-bottom:24px;border-radius:4px;color:#444;background:#e7f2fa}.notice p:last-child{margin-bottom:0}.notice-title{margin:-18px -18px 12px;padding:4px 18px;border-radius:4px 4px 0 0;font-weight:700;color:#fff;background:#6ab0de}.notice-title:before{margin-right:8px;font-family:"Font Awesome 5 Free",FontAwesome;font-weight:400}.notice.warning .notice-title{background:rgba(217,83,79,.9)}.notice.warning .notice-title:before{content:'\f071'}.notice.warning{background:#fae2e2}.notice.info .notice-title{background:#f0b37e}.notice.info .notice-title:before{content:'\f05a'}.notice.info{background:#fff2db}.notice.note .notice-title{background:#6ab0de}.notice.note .notice-title:before{content:'\f06a'}.notice.note{background:#e7f2fA}.notice.tip .notice-title{background:rgba(92,184,92,.8)}.notice.tip .notice-title:before{content:'\f058'}.notice.tip{background:#e6f9e6}</style>
+<style type="text/css">
+.notice{
+    padding:18px;
+    line-height:24px;
+    margin-bottom:24px;
+    border-radius:4px;
+    color:#444;
+    background:#e7f2fa
+}
+.notice p:last-child{
+    margin-bottom:0
+}
+.notice-title{
+    margin:-18px -18px 12px;
+    padding:4px 18px;
+    border-radius:4px 4px 0 0;
+    font-weight:700;
+    color:#fff;
+    background:#6ab0de
+}
+.notice-title:before{
+    margin-right:8px;
+    font-family:"Font Awesome 5 Free",FontAwesome;
+    font-weight:400
+}
+.notice.warning .notice-title{
+    background:rgba(217,83,79,.9)
+}
+.notice.warning{
+    background:#fae2e2
+}
+.notice.info .notice-title{
+    background:#f0b37e
+}
+.notice.info{
+    background:#fff2db
+}
+.notice.note .notice-title{
+    background:#6ab0de
+}
+.notice.note{
+    background:#e7f2fA
+}
+.notice.tip .notice-title{
+    background:rgba(92,184,92,.8)
+}
+.notice.tip{
+    background:#e6f9e6
+}
+</style>
 {{- end -}}
 {{- $.Page.Scratch.Add "noticecount" 1 -}}
 <div class="notice {{ $noticeType }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>


### PR DESCRIPTION
I really like this plugin, but I do not use Font Awesome, so the icons on the notices are broken for me.

I believe that anyone can add icons to their notices, just by applying the same CSS that this PR removes:

```css
.notice-title:before{margin-right:8px;font-family:"Font Awesome 5 Free",FontAwesome;font-weight:400}
.notice.warning .notice-title:before{content:'\f071'}
.notice.info .notice-title:before{content:'\f05a'}
.notice.note .notice-title:before{content:'\f06a'}
.notice.tip .notice-title:before{content:'\f058'}
``` 
(☝️ This can even be added to the README as an extra.)

This way, the plugin is icons-agnostic and anyone can use it.

If this is not something that aligns with your vision about this plugin, feel free to close this PR. I do not mind maintaining a fork that is FontAwesome-free.

Thanks for your work! 🙇 