### PR TITLE
Simplify color settings

### DIFF
--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -126,7 +126,7 @@
 {{- end -}}
 
 <div class="notice {{ $noticeType }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
-    <p class="notice-title">
+    <p class="first notice-title">
         <span class="icon-notice baseline">
             {{ printf "icons/%s.svg" $noticeType | readFile | safeHTML }}
         </span>

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -5,8 +5,8 @@
 {{- $raw := (markdownify .Inner | chomp) -}}
 {{- $block := findRE "(?is)^<(?:address|article|aside|blockquote|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h(?:1|2|3|4|5|6)|header|hgroup|hr|li|main|nav|noscript|ol|output|p|pre|section|table|tfoot|ul|video)\\b" $raw 1 -}}
 
-{{/* Count how many times we've called this shortcode and load the css if it's the first time */}}
-{{- if not ($.Page.Scratch.Get "noticecount") -}}
+{{/* Load the css if it's the first time */}}
+{{- if not ($.Page.Scratch.Get "notice-style-loaded-flag") -}}
 <style type="text/css">
     .notice {
         --root-color: #444;
@@ -128,9 +128,8 @@
         position: relative
     }
 </style>
+{{- $.Page.Scratch.Set "notice-style-loaded-flag" true -}}
 {{- end -}}
-
-{{- $.Page.Scratch.Add "noticecount" 1 -}}
 
 <div class="notice {{ $noticeType }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
     <p class="first notice-title">

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -5,8 +5,8 @@
 {{- $raw := (markdownify .Inner | chomp) -}}
 {{- $block := findRE "(?is)^<(?:address|article|aside|blockquote|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h(?:1|2|3|4|5|6)|header|hgroup|hr|li|main|nav|noscript|ol|output|p|pre|section|table|tfoot|ul|video)\\b" $raw 1 -}}
 
-{{/* Load the css if it's the first time */}}
-{{- if not ($.Page.Scratch.Get "notice-style-loaded-flag") -}}
+{{/* Count how many times we've called this shortcode and load the css if it's the first time */}}
+{{- if not ($.Page.Scratch.Get "noticecount") -}}
 <style type="text/css">
     /* Light theme */
     .notice {
@@ -122,8 +122,9 @@
         position: relative;
     }
 </style>
-{{- $.Page.Scratch.Set "notice-style-loaded-flag" true -}}
 {{- end -}}
+
+{{- $.Page.Scratch.Add "noticecount" 1 -}}
 
 <div class="notice {{ $noticeType }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
     <p class="first notice-title">

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,14 +1,143 @@
 {{/* Available notice types: warning, info, note, tip */}}
 {{- $noticeType := .Get 0 | default "note" -}}
+
 {{/* Workaround markdownify inconsistency for single/multiple paragraphs */}}
 {{- $raw := (markdownify .Inner | chomp) -}}
 {{- $block := findRE "(?is)^<(?:address|article|aside|blockquote|canvas|dd|div|dl|dt|fieldset|figcaption|figure|footer|form|h(?:1|2|3|4|5|6)|header|hgroup|hr|li|main|nav|noscript|ol|output|p|pre|section|table|tfoot|ul|video)\\b" $raw 1 -}}
+
 {{/* Count how many times we've called this shortcode and load the css if it's the first time */}}
 {{- if not ($.Page.Scratch.Get "noticecount") -}}
-<style type="text/css">.notice{--root-color:#444;--root-background:#eff;--title-color:#fff;--title-background:#7bd;--warning-title:#c33;--warning-content:#fee;--info-title:#fb7;--info-content:#fec;--note-title:#6be;--note-content:#e7f2fa;--tip-title:#5a5;--tip-content:#efe}@media (prefers-color-scheme:dark){.notice{--root-color:#ddd;--root-background:#eff;--title-color:#fff;--title-background:#7bd;--warning-title:#800;--warning-content:#400;--info-title:#a50;--info-content:#420;--note-title:#069;--note-content:#023;--tip-title:#363;--tip-content:#121}}body.dark .notice{--root-color:#ddd;--root-background:#eff;--title-color:#fff;--title-background:#7bd;--warning-title:#800;--warning-content:#400;--info-title:#a50;--info-content:#420;--note-title:#069;--note-content:#023;--tip-title:#363;--tip-content:#121}.notice{padding:18px;line-height:24px;margin-bottom:24px;border-radius:4px;color:var(--root-color);background:var(--root-background)}.notice p:last-child{margin-bottom:0}.notice-title{margin:-18px -18px 12px;padding:4px 18px;border-radius:4px 4px 0 0;font-weight:700;color:var(--title-color);background:var(--title-background)}.notice.warning .notice-title{background:var(--warning-title)}.notice.warning{background:var(--warning-content)}.notice.info .notice-title{background:var(--info-title)}.notice.info{background:var(--info-content)}.notice.note .notice-title{background:var(--note-title)}.notice.note{background:var(--note-content)}.notice.tip .notice-title{background:var(--tip-title)}.notice.tip{background:var(--tip-content)}.icon-notice{display:inline-flex;align-self:center;margin-right:8px}.icon-notice img,.icon-notice svg{height:1em;width:1em;fill:currentColor}.icon-notice img,.icon-notice.baseline svg{top:.125em;position:relative}</style>
+<style type="text/css">
+    .notice {
+        --root-color: #444;
+        --root-background: #eff;
+        --title-color: #fff;
+        --title-background: #7bd;
+        --warning-title: #c33;
+        --warning-content: #fee;
+        --info-title: #fb7;
+        --info-content: #fec;
+        --note-title: #6be;
+        --note-content: #e7f2fa;
+        --tip-title: #5a5;
+        --tip-content: #efe
+    }
+
+    @media (prefers-color-scheme:dark) {
+        .notice {
+            --root-color: #ddd;
+            --root-background: #eff;
+            --title-color: #fff;
+            --title-background: #7bd;
+            --warning-title: #800;
+            --warning-content: #400;
+            --info-title: #a50;
+            --info-content: #420;
+            --note-title: #069;
+            --note-content: #023;
+            --tip-title: #363;
+            --tip-content: #121
+        }
+    }
+
+    body.dark .notice {
+        --root-color: #ddd;
+        --root-background: #eff;
+        --title-color: #fff;
+        --title-background: #7bd;
+        --warning-title: #800;
+        --warning-content: #400;
+        --info-title: #a50;
+        --info-content: #420;
+        --note-title: #069;
+        --note-content: #023;
+        --tip-title: #363;
+        --tip-content: #121
+    }
+
+    .notice {
+        padding: 18px;
+        line-height: 24px;
+        margin-bottom: 24px;
+        border-radius: 4px;
+        color: var(--root-color);
+        background: var(--root-background)
+    }
+
+    .notice p:last-child {
+        margin-bottom: 0
+    }
+
+    .notice-title {
+        margin: -18px -18px 12px;
+        padding: 4px 18px;
+        border-radius: 4px 4px 0 0;
+        font-weight: 700;
+        color: var(--title-color);
+        background: var(--title-background)
+    }
+
+    .notice.warning .notice-title {
+        background: var(--warning-title)
+    }
+
+    .notice.warning {
+        background: var(--warning-content)
+    }
+
+    .notice.info .notice-title {
+        background: var(--info-title)
+    }
+
+    .notice.info {
+        background: var(--info-content)
+    }
+
+    .notice.note .notice-title {
+        background: var(--note-title)
+    }
+
+    .notice.note {
+        background: var(--note-content)
+    }
+
+    .notice.tip .notice-title {
+        background: var(--tip-title)
+    }
+
+    .notice.tip {
+        background: var(--tip-content)
+    }
+
+    .icon-notice {
+        display: inline-flex;
+        align-self: center;
+        margin-right: 8px
+    }
+
+    .icon-notice img,
+    .icon-notice svg {
+        height: 1em;
+        width: 1em;
+        fill: currentColor
+    }
+
+    .icon-notice img,
+    .icon-notice.baseline svg {
+        top: .125em;
+        position: relative
+    }
+</style>
 {{- end -}}
+
 {{- $.Page.Scratch.Add "noticecount" 1 -}}
+
 <div class="notice {{ $noticeType }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
-<p class="first notice-title"><span class="icon-notice baseline">{{ printf "icons/%s.svg" $noticeType | readFile | safeHTML }}</span>{{- i18n $noticeType -}}</p>
-{{- if or $block (not $raw) }}{{ $raw }}{{ else }}<p>{{ $raw }}</p>{{ end -}}
+    <p class="first notice-title">
+        <span class="icon-notice baseline">
+            {{ printf "icons/%s.svg" $noticeType | readFile | safeHTML }}
+        </span>
+        {{- i18n $noticeType -}}
+    </p>
+    {{- if or $block (not $raw) }}{{ $raw }}{{ else }}<p>{{ $raw }}</p>{{ end -}}
 </div>

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -141,7 +141,7 @@
 {{- end -}}
 
 <div class="notice {{ $noticeType }}" {{ if len .Params | eq 2 }} id="{{ .Get 1 }}" {{ end }}>
-    <p class="first notice-title">
+    <p class="notice-title">
         <span class="icon-notice baseline">
             {{ printf "icons/%s.svg" $noticeType | readFile | safeHTML }}
         </span>

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -11,13 +11,8 @@
     /* Light theme */
     .notice {
         --title-color: #fff;
-        --title-background-color: #7bd;
-        --content-color: #444;
-        --content-background-color: #eff;
-    }
-
-    .notice.note {
         --title-background-color: #6be;
+        --content-color: #444;
         --content-background-color: #e7f2fa;
     }
 
@@ -40,13 +35,8 @@
     @media (prefers-color-scheme:dark) {
         .notice {
             --title-color: #fff;
-            --title-background-color: #7bd;
-            --content-color: #ddd;
-            --content-background-color: #eff;
-        }
-
-        .notice.note {
             --title-background-color: #069;
+            --content-color: #ddd;
             --content-background-color: #023;
         }
 
@@ -68,13 +58,8 @@
 
     body.dark .notice {
         --title-color: #fff;
-        --title-background-color: #7bd;
-        --content-color: #ddd;
-        --content-background-color: #eff;
-    }
-
-    body.dark .notice.note {
         --title-background-color: #069;
+        --content-color: #ddd;
         --content-background-color: #023;
     }
 

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -8,124 +8,133 @@
 {{/* Load the css if it's the first time */}}
 {{- if not ($.Page.Scratch.Get "notice-style-loaded-flag") -}}
 <style type="text/css">
+    /* Light theme */
     .notice {
-        --root-color: #444;
-        --root-background: #eff;
         --title-color: #fff;
-        --title-background: #7bd;
-        --warning-title: #c33;
-        --warning-content: #fee;
-        --info-title: #fb7;
-        --info-content: #fec;
-        --note-title: #6be;
-        --note-content: #e7f2fa;
-        --tip-title: #5a5;
-        --tip-content: #efe
+        --title-background-color: #7bd;
+        --content-color: #444;
+        --content-background-color: #eff;
     }
 
+    .notice.note {
+        --title-background-color: #6be;
+        --content-background-color: #e7f2fa;
+    }
+
+    .notice.info {
+        --title-background-color: #fb7;
+        --content-background-color: #fec;
+    }
+
+    .notice.tip {
+        --title-background-color: #5a5;
+        --content-background-color: #efe;
+    }
+
+    .notice.warning {
+        --title-background-color: #c33;
+        --content-background-color: #fee;
+    }
+
+    /* Dark theme */
     @media (prefers-color-scheme:dark) {
         .notice {
-            --root-color: #ddd;
-            --root-background: #eff;
             --title-color: #fff;
-            --title-background: #7bd;
-            --warning-title: #800;
-            --warning-content: #400;
-            --info-title: #a50;
-            --info-content: #420;
-            --note-title: #069;
-            --note-content: #023;
-            --tip-title: #363;
-            --tip-content: #121
+            --title-background-color: #7bd;
+            --content-color: #ddd;
+            --content-background-color: #eff;
+        }
+
+        .notice.note {
+            --title-background-color: #069;
+            --content-background-color: #023;
+        }
+
+        .notice.info {
+            --title-background-color: #a50;
+            --content-background-color: #420;
+        }
+
+        .notice.tip {
+            --title-background-color: #363;
+            --content-background-color: #121;
+        }
+
+        .notice.warning {
+            --title-background-color: #800;
+            --content-background-color: #400;
         }
     }
 
     body.dark .notice {
-        --root-color: #ddd;
-        --root-background: #eff;
         --title-color: #fff;
-        --title-background: #7bd;
-        --warning-title: #800;
-        --warning-content: #400;
-        --info-title: #a50;
-        --info-content: #420;
-        --note-title: #069;
-        --note-content: #023;
-        --tip-title: #363;
-        --tip-content: #121
+        --title-background-color: #7bd;
+        --content-color: #ddd;
+        --content-background-color: #eff;
     }
 
+    body.dark .notice.note {
+        --title-background-color: #069;
+        --content-background-color: #023;
+    }
+
+    body.dark .notice.info {
+        --title-background-color: #a50;
+        --content-background-color: #420;
+    }
+
+    body.dark .notice.tip {
+        --title-background-color: #363;
+        --content-background-color: #121;
+    }
+
+    body.dark .notice.warning {
+        --title-background-color: #800;
+        --content-background-color: #400;
+    }
+
+    /* Content */
     .notice {
         padding: 18px;
         line-height: 24px;
         margin-bottom: 24px;
         border-radius: 4px;
-        color: var(--root-color);
-        background: var(--root-background)
+        color: var(--content-color);
+        background: var(--content-background-color);
     }
 
     .notice p:last-child {
         margin-bottom: 0
     }
 
+    /* Title */
     .notice-title {
         margin: -18px -18px 12px;
         padding: 4px 18px;
         border-radius: 4px 4px 0 0;
         font-weight: 700;
         color: var(--title-color);
-        background: var(--title-background)
+        background: var(--title-background-color);
     }
 
-    .notice.warning .notice-title {
-        background: var(--warning-title)
-    }
-
-    .notice.warning {
-        background: var(--warning-content)
-    }
-
-    .notice.info .notice-title {
-        background: var(--info-title)
-    }
-
-    .notice.info {
-        background: var(--info-content)
-    }
-
-    .notice.note .notice-title {
-        background: var(--note-title)
-    }
-
-    .notice.note {
-        background: var(--note-content)
-    }
-
-    .notice.tip .notice-title {
-        background: var(--tip-title)
-    }
-
-    .notice.tip {
-        background: var(--tip-content)
-    }
-
+    /* Icon */
     .icon-notice {
         display: inline-flex;
         align-self: center;
-        margin-right: 8px
+        margin-right: 8px;
     }
 
     .icon-notice img,
     .icon-notice svg {
         height: 1em;
         width: 1em;
-        fill: currentColor
+        fill: currentColor;
     }
 
     .icon-notice img,
     .icon-notice.baseline svg {
         top: .125em;
-        position: relative
+        position: relative;
     }
 </style>
 {{- $.Page.Scratch.Set "notice-style-loaded-flag" true -}}


### PR DESCRIPTION
Seems no bug after update.

Light theme

<img width="829" alt="image" src="https://github.com/martignoni/hugo-notice/assets/93363751/00e4d742-ab8f-42bc-a966-074f45dfbc00">

Dark theme

<img width="810" alt="image" src="https://github.com/martignoni/hugo-notice/assets/93363751/95a6b138-d4ca-424f-8ce3-cc4d9d80f068">

Source code

    ## Test
    
    {{< notice note >}}
    This is a very good note.
    {{< /notice >}}
    
    {{< notice info >}}
    This is a very good info.
    {{< /notice >}}
    
    {{< notice tip >}}
    This is a very good tip.
    {{< /notice >}}
    
    {{< notice warning >}}
    This is a warning notice. Be warned!
    {{< /notice >}}
    
    {{< notice Others >}}
    Non-default type.
    {{< /notice >}}