### PR TITLE
Add a way to replace the title with another string

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ This is a very good tip.
 {{< /notice >}}
 ```
 
+You may also change the the title of the notice by providing a string as a second argument:
+
+```go
+{{< notice tip "A New Title" >}}
+This is a very good tip with a different title.
+{{< /notice >}}
+```
+
+Note that unlike the built-in ones, these titles are not translatable by hugo-notice. If you need translation, you will need to translate them before passing them in.
+
 ### Enabling dark mode
 
 We recommend that you use the standard [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) CSS media feature to detect if a user has requested light or dark color themes. In this case, dark mode will work automatically. The `prefers-color-scheme` media feature is fully supported by all modern browsers.

--- a/layouts/shortcodes/notice.html
+++ b/layouts/shortcodes/notice.html
@@ -1,5 +1,6 @@
 {{/* Available notice types: warning, info, note, tip */}}
 {{- $noticeType := .Get 0 | default "note" -}}
+{{- $title := .Get 1 | default "" -}}
 
 {{/* Workaround markdownify inconsistency for single/multiple paragraphs */}}
 {{- $raw := (markdownify .Inner | chomp) -}}
@@ -130,7 +131,7 @@
         <span class="icon-notice baseline">
             {{ printf "icons/%s.svg" $noticeType | readFile | safeHTML }}
         </span>
-        {{- i18n $noticeType -}}
+        {{- if $title }} {{ $title }} {{ else }} {{ i18n $noticeType }} {{ end -}}
     </p>
     {{- if or $block (not $raw) }}{{ $raw }}{{ else }}<p>{{ $raw }}</p>{{ end -}}
 </div>


### PR DESCRIPTION
```go
{{< notice note "Some Other Title" >}}
```

Will result in a note with a title of "Some Other Title".

Fixes https://github.com/martignoni/hugo-notice/issues/49